### PR TITLE
fix: solid left border in doc mod

### DIFF
--- a/src/bullet_threading.scss
+++ b/src/bullet_threading.scss
@@ -155,3 +155,6 @@
 .doc-mode .ls-block::after {
   display: none;
 }
+.doc-mode .block-children {
+  border-left-width: 0px !important;
+}


### PR DESCRIPTION
In document mod, this is a solid left boder line 

![image](https://user-images.githubusercontent.com/15816040/164187440-b41a9b3b-bbe4-471f-8b11-3926c78e27ce.png)

I find some code in `bullet_threading.scss`
```scss
.block-children {
  border-left-color: var(--ls-guideline-color);
  // Must override this to make it compatible with other themes
  border-left-width: var(--ls-block-bullet-threading-width) !important;
}
```
`boder-left-width` override the style in document mode, which should be 0.

Default theme in document mode 
<img width="338" alt="image" src="https://user-images.githubusercontent.com/15816040/164188525-1450e352-e1da-490e-9138-c1e1bbcdeb08.png">

my work
<img width="312" alt="image" src="https://user-images.githubusercontent.com/15816040/164189339-0ec175cd-5702-4609-aff5-a9ea03d3f2fc.png">

