### PR TITLE
fix: query header display issue

### DIFF
--- a/src/_queries.scss
+++ b/src/_queries.scss
@@ -19,11 +19,7 @@
 
 .dsl-query .custom-query-title > .font-medium,
 :not(.dsl-query) > .custom-query .custom-query-title {
-  display: inline-block;
   opacity: 1;
-  padding: 2px 10px !important;
-  background: var(--ct-query-header-background);
-  color: var(--ct-query-header-color);
   font-family: var(--ct-code-font-family);
   font-size: var(--ct-inline-code-font-size);
   font-style: var(--ct-inline-code-font-style) !important;


### PR DESCRIPTION
## Motivation

Fix #65 

I observed a difference in the DOM structure between the Web and the Desktop:

<img width="930" alt="image" src="https://user-images.githubusercontent.com/38807139/172673072-d4711004-9a20-484e-b101-e2977b4eba82.png">

So, this led me to guess if this part of the CSS style was specifically designed for the desktop, so I didn't choose to remove or rewrite it.

I chose to remove the part that caused the misstyling, that's all.

<img width="818" alt="Xnip2022-06-09_00-45-39" src="https://user-images.githubusercontent.com/38807139/172673901-4fa0671f-f510-4557-adab-96598359c3b6.png">
