### PR TITLE
fix(blocks): code block references are not displayed properly

### DIFF
--- a/src/_blocks.scss
+++ b/src/_blocks.scss
@@ -27,6 +27,10 @@
   display: inline;
 }
 
+.block-ref .block-body > .cp__fenced-code-block div {
+    display: block !important;
+}
+
 .block-ref .flex.flex-row.justify-between {
   display: inline;
 }


### PR DESCRIPTION
fix Issues : https://github.com/pengx17/logseq-dev-theme/issues/83