### PR TITLE
fix(scheduled): add space between content, time cost and scheduled date when references

### DIFF
--- a/src/_blocks.scss
+++ b/src/_blocks.scss
@@ -134,3 +134,16 @@ a:hover > .bullet-container .bullet {
   opacity: 0.6 !important;
   transform: scale(0.9);
 }
+
+// https://github.com/pengx17/logseq-dev-theme/issues/77 
+// add space between content, time cost and scheduled date when references
+.block-ref a.fade-link::before, .block-ref a.fade-link::after,
+.block-ref .timestamp .opacity-80::before, .block-ref .timestamp .opacity-80::after {
+    content: "    ";
+}
+
+.block-ref a.fade-link,
+.block-ref .timestamp-label, 
+.block-ref .timestamp .opacity-80 {
+    font-size: 75% !important;
+}


### PR DESCRIPTION
Fix: https://github.com/pengx17/logseq-dev-theme/issues/77

After:
![image](https://user-images.githubusercontent.com/32270702/207560431-834e0658-503d-419a-b0b5-e7042b4ec79f.png)


