### PR TITLE
fix(bullet_threading): update bullet_threading.scss for Logseq 0.9.6

### DIFF
--- a/src/bullet_threading.scss
+++ b/src/bullet_threading.scss
@@ -84,7 +84,7 @@
     pointer-events: none;
     content: "";
     left: calc(var(--ls-block-bullet-threading-width) * -1);
-    right: 6px;
+    right: 20px;
     top: calc(-50% + var(--ls-block-bullet-threading-width) * 0.5 - 1px);
     bottom: 50%;
     /* shift left 1px for border */
@@ -123,7 +123,7 @@
       content: "";
       top: 12px;
       bottom: 0;
-      left: -15px;
+      left: -21px;
       position: absolute;
       border-left: var(--ls-block-bullet-threading-width) solid transparent;
     }


### PR DESCRIPTION
Fixes https://github.com/pengx17/logseq-plugin-bullet-threading/issues/18

**Before**

![](https://user-images.githubusercontent.com/6618943/238020791-7194a550-57ac-4c75-99a0-26bb822c5d79.png)

**After**

<img width="480" alt="Screenshot 2023-05-12 at 4 43 28 PM" src="https://github.com/pengx17/logseq-dev-theme/assets/10522258/b9173079-b566-494c-a22a-0497a0568511">
