### PR TITLE
fix: fix block fold button on mobile

### DIFF
--- a/src/_blocks.scss
+++ b/src/_blocks.scss
@@ -84,9 +84,13 @@ a:hover > .bullet-container .bullet {
   margin-left: 0 !important;
 }
 
-.ls-block div.items-center {
-  position: relative;
-  height: 26px !important;
+// .ls-block div.items-center {
+//   position: relative;
+//   height: 26px !important;
+// }
+.ls-block div.block-control-wrap {
+    position: relative;
+    height: 26px !important;
 }
 
 // hovering block indicator

--- a/src/bullet_threading.scss
+++ b/src/bullet_threading.scss
@@ -59,11 +59,16 @@
     box-shadow: 0 0 0 1px var(--ls-block-bullet-active-color);
   }
 
-  div.items-center {
-    position: relative;
-    height: 26px !important;
-  }
+//   div.items-center {
+//     position: relative;
+//     height: 26px !important;
+//   }
 
+  div.block-control-wrap {
+      position: relative;
+      height: 26px !important;
+  }
+  
   /* Fix for headings like h1, h2 etc */
   > .items-baseline {
     align-items: initial;


### PR DESCRIPTION
Fix: https://github.com/pengx17/logseq-dev-theme/issues/90, https://github.com/pengx17/logseq-dev-theme/issues/86

## main cause: `position: relative;`

The following code is mainly used for bullet threading.

```scss
.ls-block div.items-center {
  position: relative;
  height: 26px !important;
}
``` 
- https://github.com/pengx17/logseq-dev-theme/blob/9b72ab554d46882bbd7bb806295e0b315616cbb6/src/_blocks.scss#L87
- https://github.com/pengx17/logseq-dev-theme/blob/9b72ab554d46882bbd7bb806295e0b315616cbb6/src/bullet_threading.scss#L62

## solution

Replace `items-center` with `block-control-wrap` for more precise positioning.

```scss
.ls-block div.block-control-wrap {
    position: relative;
    height: 26px !important;
}
```

![image](https://github.com/pengx17/logseq-dev-theme/assets/32270702/bd66f863-c0ca-46f3-88a9-557e2775ad78)
![image](https://github.com/pengx17/logseq-dev-theme/assets/32270702/3ef8091e-9f19-4237-93be-16173ce15fa9)


