### PR TITLE
apply dark theme to pdf viewer

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1272,3 +1272,28 @@ html[data-theme=white] {
 :root {
   --ls-block-bullet-threading-width: 2px;
 }
+
+/* PDF viewer */
+.extensions__pdf-settings-item.theme-picker>button.dark {
+    background-color: var(--ls-primary-background-color);
+}
+.extensions__pdf-container {
+  background-color: transparent;
+
+  &[data-theme=dark] {
+    background-color: #262E37; /* not sure how to do this without hardcoding */ 
+
+    .textLayer {
+      background-color: var(--ls-primary-background-color);
+      opacity: 1;
+      /* mix-blend-mode: multiply; */
+    }
+
+    .extensions__pdf-hls-text-region {
+      mix-blend-mode: normal;
+      opacity: .4;
+    }
+
+  }
+}
+


### PR DESCRIPTION
Hi peng,
I tried matching the dark theme in the PDF viewer. I never coded CSS before though so not sure how match the margin color without hard-coding hex values.
Here's how it looked on my end:
<img width="2066" alt="Screen Shot 2023-09-28 at 4 09 41 pm" src="https://github.com/pengx17/logseq-dev-theme/assets/87298334/8a7bdac4-5a40-4721-ad71-6b0a222a8251">
My `custom.css`:
```
@import url("https://cdn.jsdelivr.net/gh/pengx17/logseq-dev-theme@main/custom.css");
.dark-theme .image-resize {
  filter: brightness(1) saturate(1);
}
blockquote {
  background-color: #2C3333;
  border-left: 5px solid;
  display: block;
  margin: 1rem 0;
  padding: 8px 20px;
  text-indent: 0;
  border-radius: 2px;
}

.extensions__pdf-settings-item.theme-picker>button.dark {
    background-color: #272c35;
}
.extensions__pdf-container {
  background-color: transparent;

  &[data-theme=dark] {
    background-color: #262E37;

    .textLayer {
      background-color: #272c35;
      opacity: 1;
      /* mix-blend-mode: multiply; */
    }

    .extensions__pdf-hls-text-region {
      mix-blend-mode: normal;
      opacity: .4;
    }

  }
}
```